### PR TITLE
Store用のsign_in機能の実装

### DIFF
--- a/app/views/stores/index.html.erb
+++ b/app/views/stores/index.html.erb
@@ -1,0 +1,19 @@
+<header class="header">
+  <div class="header_bar">
+    <h1 class="title_name"><p class="title_name_parag">獺祭書屋</p></h1>
+    <div class="nav">
+      <ul class="nav_list">
+        <li class="stores_logout_button">
+          <%= link_to "ログアウト", destroy_store_session_path, class: 'post'%>
+        </li>
+        <li class="stores_add_books_button">
+          <%= link_to "書籍の登録・追加", '/stores/new', class: 'post'%>
+        </li>
+        <li class="stores_edit_books_button">
+          <%= link_to "書籍の在庫増減・削除", '/stores/:id', class: 'post'%>
+        </li>
+      </ul>
+    </div>
+  </div>
+</header>
+

--- a/app/views/stores/sessions/new.html.erb
+++ b/app/views/stores/sessions/new.html.erb
@@ -1,26 +1,17 @@
-<h2>Log in</h2>
+<h2>Store ログイン</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+<%= form_for(resource, as: resource_name, url: session_path) do |f| %>
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :メールアドレス %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="field">
-    <%= f.label :password %><br />
+    <%= f.label :パスワード %><br />
     <%= f.password_field :password, autocomplete: "current-password" %>
   </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
-
   <div class="actions">
-    <%= f.submit "Log in" %>
+    <%= f.submit "ログイン" %>
   </div>
 <% end %>
-
-<%= render "stores/shared/links" %>


### PR DESCRIPTION
# WHAT
ログイン画面である、stores/sessionsディレクトリ下のnew.html.erbの記述を追加しました。
ログイン後のページの遷移先である、storesディレクトリ下のindex.html.erbに記述を追加しました。

# WHY
ログイン後のページは、userログイン後のページの作成が完了次第取り組みます。

controllersディレクトリ下のapplication_controller.rbでuserがログインしている場合、store側のログインをできないようにしています。それにより、user側でログアウトする必要が出てきますが、この機能の実装も後日行いたいと思います。

もしかしたら、userログイン後のページ遷移先をviews/booksディレクトリ下のnew.html.erbではなく、views/usersディレクトリ下にindex.html.erbを作成を検討しています。カート機能の実装で息詰まったら、変更するかもしれません。